### PR TITLE
feat: allow opts.map to be overriden

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ let postcss = require('postcss'),
     mergeSourceMap = require('merge-source-map');
 
 module.exports = postcss.plugin('postcss-node-sass', opt => (root, result) => {
+    const map = typeof result.opts.map === 'object' ? result.opts.map : {}
     let css = root.toResult(Object.assign(result.opts, {
-        map: { annotation: false, inline: false, sourcesContent: true }
+        map: Object.assign({ annotation: false, inline: false, sourcesContent: true }, map)
     }));
     opt = Object.assign({
         indentWidth: 4,


### PR DESCRIPTION
For a project I'm working on I want `sourcesContent` to be `false` and `annotation` to be `true`. However this plugin overrides those options with its own and there is no way I can force it. 

This PR allows me to override the `map` options with my own based on the options I provide to postcss.