### PR TITLE
fix: pass correct sourcemap to postcss from node-sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@
  */
 
 let postcss = require('postcss'),
-    sass = require('node-sass'),
-    mergeSourceMap = require('merge-source-map');
+    sass = require('node-sass');
 
 module.exports = postcss.plugin('postcss-node-sass', opt => (root, result) => {
     const map = typeof result.opts.map === 'object' ? result.opts.map : {}
@@ -29,7 +28,7 @@ module.exports = postcss.plugin('postcss-node-sass', opt => (root, result) => {
     )).then(res => postcss.parse(res.css.toString(), {
         from: result.opts.from,
         map: {
-            prev: mergeSourceMap(css.map.toJSON(), JSON.parse(css.map))
+            prev: JSON.parse(res.map.toString())
         }
     })).then(res => {
         result.root = res;


### PR DESCRIPTION
In trying to get the sourcemaps working I've noticed the sourcemaps were broken - this is because the sourcemap from node-sass was never passed to postcss. It only read its own sourcemap. Additionally merging them left more bugs. Ultimately I went with just passing the node-sass sourcemap and this works for me.