### PR TITLE
feat: emit dependency messages for all included files

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,21 @@ module.exports = postcss.plugin('postcss-node-sass', opt => (root, result) => {
         file: result.opts.from,
         outFile: result.opts.to
     });
+    let includedFiles
     return new Promise((resolve, reject) => sass.render(
         opt,
         (err, res) => err ? reject(err) : resolve(res)
-    )).then(res => postcss.parse(res.css.toString(), {
-        from: result.opts.from,
-        map: {
-            prev: JSON.parse(res.map.toString())
-        }
-    })).then(res => {
+    )).then(res => {
+        includedFiles = res.stats.includedFiles.filter((item, pos, array) => array.indexOf(item) === pos)
+        return postcss.parse(res.css.toString(), {
+            from: result.opts.from,
+            map: {
+                prev: JSON.parse(res.map.toString())
+            }
+        })
+    }).then(res => {
         result.root = res;
+        result.messages = includedFiles.map(file => ({ type: 'dependency', parent: result.opts.from, file }))
     });
+
 });


### PR DESCRIPTION
I'm using [`postcss-cli`](https://github.com/postcss/postcss-cli) coupled with this plugin so I can use postcss to generate my sass files, and postcss-cli can watch for changes and recompile.

To watch for changes, postcss-cli needs to be informed of all dependencies that the CSS bundle has. It uses the `messages` of a postcss plugin to find the `"dependencies"` messages, and watches each file from this. 

This PR adds those messages to the output, so that `postcss-cli` can pick them up and start watching them.