### PR TITLE
Handle when res.map is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = postcss.plugin('postcss-node-sass', opt => (root, result) => {
         return postcss.parse(res.css.toString(), {
             from: result.opts.from,
             map: {
-                prev: JSON.parse(res.map.toString())
+                prev: res.map ? JSON.parse(res.map.toString()) : ''
             }
         })
     }).then(res => {


### PR DESCRIPTION
First, thank you for this useful plugin!

Few days ago I found that sometime transpile from SASS to CSS was failed because of following error:

```shell
TypeError: Cannot read property 'toString' of undefined
    at Promise.then.res (postcss-node-sass/index.js:38:42)
```

I investigated the reason why this error was occurred. PostCSS pass `result` parameter to each plugin. For some reasons, sometime `result.opts.to` is `null`, and in this case, node-sass doesn't generate source map because `opt.outFile` is not specified ([postcss-node-sass/index.js#L27](https://github.com/arpadHegedus/postcss-node-sass/blob/master/index.js#L27), [node-sass/index.js#L54-L56](https://github.com/sass/node-sass/blob/master/lib/index.js#L54-L56)).

To handle this case, I did small fix. Please review it.

Thanks.