### PR TITLE
Support Node 14: Update node-sass to 4.14.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     },
     "dependencies": {
         "merge-source-map": "^1.1.0",
-        "node-sass": "^4.10.0",
+        "node-sass": "^4.14.1",
         "postcss": "^7.0.6"
     },
     "devDependencies": {


### PR DESCRIPTION
postcss-node-sass fails to run on Node 14.  This updates the underlying native module to a version that works with the latest version of Node.js.