### PR TITLE
Node support < 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         }
     ],
     "engines": {
-        "node": ">=6.0.0"
+        "node": ">=6.0.0 <15.0.0"
     },
     "scripts": {
         "test": "jest"
@@ -61,14 +61,14 @@
     },
     "dependencies": {
         "merge-source-map": "^1.1.0",
-        "node-sass": "^4.14.1",
-        "postcss": "^8.2.7"
+        "node-sass": "^4.14.1"
     },
     "devDependencies": {
         "babel-eslint": "^10.0.1",
         "eslint": "^5.9.0",
         "eslint-config-postcss": "^3.0.6",
-        "jest": "^23.6.0"
+        "jest": "^23.6.0",
+        "postcss": "^8.2.7"
     },
     "peerDependencies": {
         "postcss": "^8.x.x"


### PR DESCRIPTION
### What does this PR do?
Limit support for pre node 15 in node engines.

### Background
`node-sass` needs to be bumped to 5.0.0 before support from node 15 works. But this will drop support for non-LTS.
https://github.com/sass/node-sass/releases