### PR TITLE
Allow passing Sass engine via plugin options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@
  */
 
 let postcss = require('postcss'),
-    sass = require('node-sass');
+    defaultNodeSass = require('node-sass');
 
 module.exports = opt => ({
     postcssPlugin: 'postcss-node-sass',
     Once (root, { result }) {
+        let sass = opt.sass || defaultNodeSass;
         let map = typeof result.opts.map === 'object' ? result.opts.map : {}
         let css = root.toResult(Object.assign(result.opts, {
             map: Object.assign({


### PR DESCRIPTION
This PR allows for a `sass` plugin option that can override the Sass rendering "engine". The default is the version of `node-sass` included in this repo, but this option allows plugin users to bring their own:

```js
// postcss.config.js
module.exports = {
  syntax: 'postcss-scss',
  plugins: [
    require('postcss-node-sass')({
      sass: require('node-sass')
    })
  ]
}
```

This was necessary to sidestep a [security vulnerability](https://www.npmjs.com/advisories/1753) in the dependency tree of `node-sass@4.14.1`. It uses the same convention as [@csstools/postcss-sass](https://github.com/csstools/postcss-sass/blob/3e232b620f7f9c30bdedfee59ffbd954af1029f0/index.js#L40-L41), which is unfortunately [unusable with postcss v8](https://github.com/csstools/postcss-sass/issues/24) until the maintainer publishes a new version.

It would probably be best to specify `node-sass` as a peer dependency so that this package isn't vulnerable to security issues with whatever version it uses, and pass that responsibility on to whoever is using the plugin.