### PR TITLE
update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     },
     "dependencies": {
         "merge-source-map": "^1.1.0",
-        "node-sass": "^4.14.1"
+        "node-sass": "^6.0.1"
     },
     "devDependencies": {
         "babel-eslint": "^10.0.1",


### PR DESCRIPTION
Attempts to resolve the vulnerability https://www.npmjs.com/advisories/1753

At path `postcss-node-sass > node-sass > meow > trim-newlines`.

Resolved by node-sass in 6.0.1: https://github.com/sass/node-sass/pull/3131